### PR TITLE
Add cache for client, cleanhttp, and duration time logger

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,6 @@
+package cache
+
+type Cache interface {
+	Set(key string, value interface{})
+	Get(key string) (interface{}, bool)
+}

--- a/cache/default_cache.go
+++ b/cache/default_cache.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"github.com/patrickmn/go-cache"
+	"time"
+)
+
+type DefaultCache struct {
+	underlying *cache.Cache
+	expirationDuration time.Duration
+}
+
+func NewDefaultCache(expirationDuration time.Duration, cleanupInterval time.Duration) DefaultCache {
+	c := cache.New(expirationDuration, cleanupInterval)
+	return DefaultCache{
+		underlying: c,
+		expirationDuration: expirationDuration,
+	}
+}
+
+func (c DefaultCache) Set(key string, value interface{}) {
+	c.underlying.Set(key, value, c.expirationDuration)
+}
+
+func (c DefaultCache) Get(key string) (interface{}, bool) {
+	return c.underlying.Get(key)
+}

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
-require github.com/stretchr/objx v0.1.0 // indirect
+require (
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,12 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-chi/chi/v5 v5.0.5 h1:l3RJ8T8TAqLsXFfah+RA6N4pydMbPwSdvNM+AFWvLUM=
 github.com/go-chi/chi/v5 v5.0.5/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/handlers.go
+++ b/handlers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/hooliganlin/simple-go-rest-api/user"
@@ -10,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"runtime/debug"
+	"time"
 )
 
 type UserInfoResponse struct {
@@ -86,7 +88,7 @@ func(h Handler) GetUserPostsHandler(w http.ResponseWriter, r *http.Request) {
 func (h Handler) MiddlewareLogger(next http.Handler) http.Handler {
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		wrappedWriter := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-
+		startTime := time.Now()
 		defer func() {
 			// Recover and record stack traces in case of a panic
 			if err := recover(); err != nil {
@@ -109,7 +111,9 @@ func (h Handler) MiddlewareLogger(next http.Handler) http.Handler {
 				Str("method", r.Method).
 				Str("body", string(body)).
 				Int("status", httpStatus).
+				Str("duration", fmt.Sprintf("%.4fms", time.Since(startTime).Seconds() * 1000)).
 				Msgf("incoming request for %s", r.URL.Path)
+			startTime = time.Now()
 		}()
 		next.ServeHTTP(wrappedWriter, r)
 	}

--- a/main.go
+++ b/main.go
@@ -4,16 +4,20 @@ import (
 	"fmt"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/hooliganlin/simple-go-rest-api/cache"
 	"github.com/hooliganlin/simple-go-rest-api/user"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rs/zerolog"
 	"net/http"
 	"os"
+	"time"
 )
 
 type AppConfig struct {
-	ServerHost string	`envconfig:"SERVER_HOST" default:"127.0.0.1"`
-	ServerPort int 		`envconfig:"SERVER_PORT" default:"8080"`
+	ServerHost			string			`envconfig:"SERVER_HOST" default:"127.0.0.1"`
+	ServerPort			int				`envconfig:"SERVER_PORT" default:"8080"`
+	CacheTTL			time.Duration	`envconfig:"CACHE_TTL" default:"5m"`
+	CacheTTLInterval	time.Duration	`envconfig:"CACHE_TTL_INTERVAL" default:"10m"`
 }
 
 func main() {
@@ -28,8 +32,11 @@ func main() {
 		logger.Fatal().Err(err)
 	}
 
+	//set cache
+	c := cache.NewDefaultCache(config.CacheTTL, config.CacheTTLInterval)
+
 	userConfig := user.NewConfig()
-	userClient := user.NewDefaultClient(userConfig)
+	userClient := user.NewDefaultClient(userConfig, c)
 	h := NewHandler(userClient, logger)
 
 	r := chi.NewRouter()

--- a/user/default_client_test.go
+++ b/user/default_client_test.go
@@ -30,7 +30,7 @@ func TestGetUserInfo(t *testing.T) {
 
 		client := NewDefaultClient(Config{
 			BaseURL: testServer.URL,
-		})
+		}, noopCache{})
 
 		u, err := client.GetUserInfo(context.Background(), "user_1")
 		if err != nil {
@@ -50,7 +50,7 @@ func TestGetUserInfo(t *testing.T) {
 
 		client := NewDefaultClient(Config{
 			BaseURL: testServer.URL,
-		})
+		}, noopCache{})
 
 		u, err := client.GetUserInfo(context.Background(), "user_1")
 		assert.Error(t, err)
@@ -87,7 +87,7 @@ func TestGetUserPosts(t *testing.T) {
 
 		client := NewDefaultClient(Config{
 			BaseURL: testServer.URL,
-		})
+		}, noopCache{})
 
 		posts, err := client.GetUserPosts(context.Background(), "user_1")
 		if err != nil {
@@ -107,9 +107,15 @@ func TestGetUserPosts(t *testing.T) {
 
 		client := NewDefaultClient(Config{
 			BaseURL: testServer.URL,
-		})
+		}, noopCache{})
 
 		_, err := client.GetUserPosts(context.Background(), "user_1")
 		assert.Error(t, err)
 	})
 }
+
+type noopCache struct {}
+func (c noopCache) Get(_ string) (interface{}, bool) {
+	return nil, false
+}
+func (c noopCache) Set(_ string, _ interface{}) {}


### PR DESCRIPTION
- Adds default in memory cache and middleware duration logger.
- Wrap http client with go-cleanhttp